### PR TITLE
Update remote standard URL

### DIFF
--- a/src/remoteStandards.ts
+++ b/src/remoteStandards.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { notifyErrored } from "./analytics";
 
-const remoteStandardBaseUri = "https://standard-jit.herokuapp.com";
+const remoteStandardBaseUri = "https://standard-jit.theo.do";
 
 export type ApiStandard = {
   url: string,


### PR DESCRIPTION
We are migrating the API away from heroku. The free plan is no longer available.

I created a DNS redirect using a theo.do subdomain to avoid having to update the extensions if this happens again in the future.

I did NOT migrate the standards uuids from heroku to fly.io, is it a problem?